### PR TITLE
Fix build on musl libc.

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -9,6 +9,7 @@
 #include <arpa/inet.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/select.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>
@@ -104,7 +105,7 @@ int RecvNonBlockUDP(char * buffer, int bytes, SOCKET s) {
 
 int SendUDPMessage(SOCKET s, const char *message, int length, char *ip, int port) {
     struct sockaddr_in sin;
-    sin.sin_port = htons((u_short)port);
+    sin.sin_port = htons((uint16_t)port);
     sin.sin_family = AF_INET;
     sin.sin_addr.s_addr = inet_addr(ip);
     return sendto(s, message, length, 0, (struct sockaddr *)&sin, sizeof(sin));


### PR DESCRIPTION
In order to use select, it's necessary to include <sys/select.h>.

Furthermore, though the cast in htons isn't strictly necessary, if it's
being made, it should be using uint16_t, which is the function signature.
u_short is a type that comes from kernel headers.