### PR TITLE
Clean up Makefile and bring it closer to conventions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ JPEG_DIR ?= /opt/libjpeg-turbo
 JPEG_INCLUDE ?= $(JPEG_DIR)/include
 JPEG_LIB ?= $(JPEG_DIR)/lib`getconf LONG_BIT`
 
-GXX   = g++
-CC    = -std=c++11 -x c++ -Wall -fPIC -no-pie
+CXX   = g++
+CXXFLAGS = -std=c++11 -Wall -fPIC -no-pie
 GTK   = `pkg-config --libs --cflags gtk+-3.0` `pkg-config --libs x11`
 #GTK  += `pkg-config --cflags --libs appindicator3-0.1`
 LIBAV = `pkg-config --libs --cflags libswscale libavutil`
 LIBS  =  -lspeex -lasound -lpthread -lm
 JPEG  = -I$(JPEG_INCLUDE) $(JPEG_LIB)/libturbojpeg.a
-SRC      = src/connection.c src/settings.c src/decoder*.c src/av.c src/usb.c
+SRC   = src/connection.c src/settings.c src/decoder*.c src/av.c src/usb.c
 USBMUXD = -lusbmuxd
 
 all: droidcam-cli droidcam
@@ -38,13 +38,15 @@ endif
 gresource: .gresource.xml icon2.png
 	glib-compile-resources .gresource.xml --generate-source --target=src/resources.c
 
+droidcam-cli: LDLIBS += $(JPEG) $(LIBAV) $(LIBS)
 droidcam-cli: src/droidcam-cli.c $(SRC)
-	$(GXX) $(CC) $^ $(JPEG) $(LIBAV) $(LIBS) -o droidcam-cli
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $@ $(LDFLAGS) $(LDLIBS)
 
+droidcam: LDLIBS += $(GTK) $(JPEG) $(LIBAV) $(LIBS)
 droidcam: src/droidcam.c src/resources.c $(SRC)
-	$(GXX) $(CC) $^ $(GTK) $(JPEG) $(LIBAV) $(LIBS) -o droidcam
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $@ $(LDFLAGS) $(LDLIBS)
 
 clean:
-	rm droidcam || true
-	rm droidcam-cli || true
+	rm -f droidcam
+	rm -f droidcam-cli
 	make -C v4l2loopback clean


### PR DESCRIPTION
If the code should be compiled as C++, one should be using CXX as the
compiler in the makefile, and the flags passed to it should be CXXFLAGS.

It wasn't possible to use implicit rules because the source directory
and the output directory are different.

Use LDLIBS for the libraries, so external build systems can easily
inject libraries they need into the build.