### PR TITLE
Add initial FreeBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ JPEG_DIR ?= /opt/libjpeg-turbo
 JPEG_INCLUDE ?= $(JPEG_DIR)/include
 JPEG_LIB ?= $(JPEG_DIR)/lib`getconf LONG_BIT`
 
-CC   = gcc
+CC  ?= gcc
 CFLAGS = -Wall -O2
 GTK   = `pkg-config --libs --cflags gtk+-3.0` `pkg-config --libs x11`
 GTK  += `pkg-config --cflags --libs appindicator3-0.1`
@@ -19,6 +19,15 @@ LIBS  =  -lspeex -lasound -lpthread -lm
 JPEG  = -I$(JPEG_INCLUDE) $(JPEG_LIB)/libturbojpeg.a
 SRC   = src/connection.c src/settings.c src/decoder*.c src/av.c src/usb.c src/queue.c
 USBMUXD = -lusbmuxd
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),FreeBSD)
+	CC   ?= gcc10 # todo: determine GCC version more elegantly
+	JPEG_DIR = /usr/local
+	JPEG_INCLUDE = $(JPEG_DIR)/include
+	JPEG_LIB = $(JPEG_DIR)/lib
+	USBMUXD = -lusbmuxd-2.0
+endif
 
 all: droidcam-cli droidcam
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -16,6 +16,12 @@
 #include <time.h>
 #include <unistd.h>
 
+#if __FreeBSD__
+#include <netinet/in.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#endif
+
 #include "common.h"
 #include "connection.h"
 

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -14,7 +14,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+
+#if __linux__
 #include <linux/limits.h>
+#endif
+
+#if __FreeBSD__
+#include <sys/limits.h>
+#endif
 
 #include "common.h"
 #include "decoder.h"

--- a/src/settings.c
+++ b/src/settings.c
@@ -9,7 +9,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#if __linux__
 #include <linux/limits.h>
+#endif
+
+#if __FreeBSD__
+#include <sys/limits.h>
+#include <sys/syslimits.h>
+#endif
 
 #include "common.h"
 #include "settings.h"

--- a/src/settings.c
+++ b/src/settings.c
@@ -16,7 +16,7 @@
 
 #if __FreeBSD__
 #include <sys/limits.h>
-#include <sys/syslimits.h>
+#include <sys/param.h>
 #endif
 
 #include "common.h"

--- a/src/usb.c
+++ b/src/usb.c
@@ -12,6 +12,10 @@
 #include <string.h>
 #include "usbmuxd.h"
 
+#if __FreeBSD__
+#include <sys/wait.h>
+#endif
+
 #include "common.h"
 #include "settings.h"
 


### PR DESCRIPTION
v4l2loopback has recently been [ported to FreeBSD](https://github.com/hselasky/webcamd/pull/9), allowing Droidcam and similar virtual camera programs to be used. This patch allows the `droidcam-cli` target to be successfully built and to run on the current FreeBSD version (13.0-RELEASE):

````
david@freebsd $ doas pkg install gmake gcc pkgconf libjpeg-turbo usbmuxd libusbmuxd alsa-lib v4l_compat speex ffmpeg webcamd

david@freebsd $ gmake droidcam-cli
cc  -Wall -O2 src/droidcam-cli.c src/connection.c src/settings.c src/decoder_snd.c src/decoder_v4l2.c src/decoder.c src/av.c src/usb.c src/queue.c -o droidcam-cli  -I/usr/local/include /usr/local/lib/libturbojpeg.a `pkg-config --libs --cflags libswscale libavutil` -lspeex -lasound -lpthread -lm -lusbmuxd-2.0

david@freebsd $ doas webcamd -B -c v4l2loopback

david@freebsd $ ./droidcam-cli 192.168.4.187 4747
Audio loopback device not found.
Is snd_aloop loaded?
Client v1.8.0
Video: /dev/video0
connecting to 192.168.4.187:4747
````

I haven't yet tried building the GUI. I'm open to any suggestions for improvement!