### PR TITLE
Continue trying when setting audio hwparams fails

### DIFF
--- a/src/decoder_snd.c
+++ b/src/decoder_snd.c
@@ -278,7 +278,7 @@ snd_pcm_t *find_snd_device(void) {
             if (set_hwparams(handle, hwparams, SND_PCM_ACCESS_MMAP_INTERLEAVED) < 0) {
                 errprint("setting audio hwparams failed\n");
                 snd_pcm_close(handle);
-                goto OUT;
+                continue;
             }
 
             if (set_swparams(handle, swparams) < 0) {


### PR DESCRIPTION
When the following situation happends, setting audio hwparams will fail.
1. Another process is capturing on the substream with different hwparams.
2. There is no playback on the same substream.

Continue trying to prevent audio being unusable.