### PR TITLE
Include libturbojpeg as required library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ GTK   = `pkg-config --libs --cflags gtk+-3.0` `pkg-config --libs x11`
 GTK  += `pkg-config --libs --cflags $(APPINDICATOR)`
 LIBAV = `pkg-config --libs --cflags libswscale libavutil`
 LIBS  =  -lspeex -lasound -lpthread -lm
-JPEG  = -I$(JPEG_INCLUDE) $(JPEG_LIB)/libturbojpeg.a
+JPEG   = `pkg-config --libs --cflags libturbojpeg`
+#JPEG  = -I$(JPEG_INCLUDE) $(JPEG_LIB)/libturbojpeg.a
 SRC   = src/connection.c src/settings.c src/decoder*.c src/av.c src/usb.c src/queue.c
 USBMUXD = -lusbmuxd
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ libasound2-dev
 libspeex-dev
 libusbmuxd-dev
 libplist-dev
+libturbojpeg0-dev
 
 gtk+-3.0               # Only needed for GUI client
 libappindicator3-dev   # Only needed for GUI client^^


### PR DESCRIPTION
For building this tool on latest Ubuntu, I needed an additional library than specified in the README.

This adds that lib to the instructions and changes the Makefile to use it instead of a manually installed version.