### PR TITLE
Update README.md: install package hint for install-dkms

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ then run `sudo ./install-video` to build the module and install it.
 
 Debian/Ubuntu and RHEL (Fedora/SUSE) based distros:
 [If your system supports DKMS](./README-DKMS.md), you can instead use `sudo ./install-dkms`.
+In this case, install the `deb-helper` package.
 
 ## Sound
 


### PR DESCRIPTION
if deb-helper package is not installed 

`sudo ./install-dkms`

fails with 

`make: dh_testdir: No such file or directory`

which is a bit obscure