### PR TITLE
Initial support for FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,16 @@ SRC   = src/connection.c src/settings.c src/decoder*.c src/av.c src/usb.c src/qu
 ifneq ($(findstring ayatana,$(APPINDICATOR)),)
 	CFLAGS += -DUSE_AYATANA_APPINDICATOR
 endif
+	
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),FreeBSD)
+	CC   ?= $(shell pkg info | grep -o '^gcc[0-9]*' | head -n 1)
+	JPEG_DIR = /usr/local
+	JPEG_INCLUDE = $(JPEG_DIR)/include
+	JPEG_LIB = $(JPEG_DIR)/lib
+	USBMUXD = -lusbmuxd-2.0
+endif
+
 
 all: droidcam-cli droidcam
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,7 @@ FreeBSD
 ========
 
 ## Initial considerations
-Please make sure that you add your user to the webcamd group after the installation of the dependencies, this can be done by running:
-
->doas pw groupmod webcamd -m $USER 
+Please make sure that you add your user to the webcamd group after the installation of the dependencies, this can be done by running `doas pw groupmod webcamd -m $USER` 
 
 You will also want to enable webcamd and the cuse module to load at boot for that you'll need to modify __/etc/rc.conf__ and __/boot/loader.conf__ with:
 
@@ -113,8 +111,4 @@ Run `gmake`, or `gmake droidcam-cli` if you wish to only build the command line 
 To install, run `doas ./install-client`
 
 ## Running
-You'll need to run
-
->doas webcamd -B -c v4l2loopback
-
-before launching droidcam
+You'll need to run `doas webcamd -B -c v4l2loopback` before launching droidcam

--- a/README.md
+++ b/README.md
@@ -84,3 +84,37 @@ To use DroidCam with Pipewire ([Source](https://gitlab.freedesktop.org/pipewire/
 * Go to the Input Devices tab
 * Check which VU meter reacts to the phone's audio input (eg. Built-in Audio Pro 1), this is the desired audio input device.
 * Inside pavucontrol you can now set this device as default input or choose it as the input device for individual apps etc.
+
+
+FreeBSD
+========
+
+## Initial considerations
+Please make sure that you add your user to the webcamd group after the installation of the dependencies, this can be done by running:
+
+>doas pw groupmod webcamd -m $USER 
+
+You will also want to enable webcamd and the cuse module to load at boot for that you'll need to modify __/etc/rc.conf__ and __/boot/loader.conf__ with:
+
+>webcamd_enable="YES"
+
+and
+
+>cuse_load="YES"
+
+respectively.
+
+## Getting all the necessary dependencies
+Run `doas pkg install gmake gcc pkgconf libjpeg-turbo usbmuxd libusbmuxd alsa-lib v4l_compat speex ffmpeg webcamd libappindicator`
+
+## Building and Installing
+Run `gmake`, or `gmake droidcam-cli` if you wish to only build the command line version of droidcam.
+
+To install, run `doas ./install-client`
+
+## Running
+You'll need to run
+
+>doas webcamd -B -c v4l2loopback
+
+before launching droidcam

--- a/install-client
+++ b/install-client
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ -z "$SUDO_USER" ]; then

--- a/install-dkms
+++ b/install-dkms
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage: ./install-dkms [640 480]
 

--- a/install-sound
+++ b/install-sound
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 REPO_PATH="$(/usr/bin/dirname $([ -L $0 ] && /bin/readlink -f $0 || echo $0))"
 source "${REPO_PATH}/install.common"

--- a/install-video
+++ b/install-video
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 REPO_PATH="$(/usr/bin/dirname $([ -L $0 ] && /bin/readlink -f $0 || echo $0))"

--- a/install.common
+++ b/install.common
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # You should not call this directly.
 # This is supposed to be sourced from install and install-dkms scripts
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -16,6 +16,12 @@
 #include <time.h>
 #include <unistd.h>
 
+#if __FreeBSD__
+#include <netinet/in.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#endif
+
 #include "common.h"
 #include "connection.h"
 

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -14,7 +14,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+
+#if __linux__
 #include <linux/limits.h>
+#endif
+
+#if __FreeBSD__
+#include <sys/limits.h>
+#endif
 
 #include "common.h"
 #include "decoder.h"

--- a/src/settings.c
+++ b/src/settings.c
@@ -9,7 +9,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#if __linux__
 #include <linux/limits.h>
+#endif
+
+#if __FreeBSD__
+#include <sys/limits.h>
+#include <sys/syslimits.h>
+#endif
 
 #include "common.h"
 #include "settings.h"

--- a/src/usb.c
+++ b/src/usb.c
@@ -12,6 +12,10 @@
 #include <string.h>
 #include "usbmuxd.h"
 
+#if __FreeBSD__
+#include <sys/wait.h>
+#endif
+
 #include "common.h"
 #include "settings.h"
 

--- a/uninstall
+++ b/uninstall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 
 if (lsmod | grep v4l2loopback_dc); then

--- a/uninstall-dkms
+++ b/uninstall-dkms
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage: ./uninstall-dkms
 


### PR DESCRIPTION
I did some modifications to some files, namely:

>connection.c
decoder.c
settings.c
usb.c

For those files above I added the necessary includes

All the installation and uninstallation scripts had their first line modified from

>#!/bin/bash

to 

>#!/usr/bin/env bash

Since in FreeBSD __bash__ is third-party software and thus is located at __/usr/local/bin/bash__ not __/bin/bash__

I reckon that using:

>#!/usr/bin/env bash

Might not be the best way to achieve "portability" due to some problems see [this](https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my), but those problems did not arise in my machine, neither on Arch, Debian, FreeBSD nor NomadBSD (a FreeBSD "distro"). If problems do arise in any other distros the line could be modified to be:

>#!/usr/bin/env -S bash

Or FreeBSD users could just make a symbolic link and keep the original line from your install scripts.

Naturally the Makefile was also modified.

The Readme.md was also modified to have instructions on how to build the package on FreeBSD.