### PR TITLE
Fixed bug introduced with commit 5693b0e that prevented the app from running in FreeBSD

### DIFF
--- a/src/decoder_v4l2.c
+++ b/src/decoder_v4l2.c
@@ -96,8 +96,10 @@ void query_v4l_device(int droidcam_device_fd, unsigned *WEBCAM_W, unsigned *WEBC
     vid_format.fmt.pix.field = V4L2_FIELD_NONE;
     xioctl(droidcam_device_fd, VIDIOC_S_FMT, &vid_format);
 
+#ifdef __linux__
     vid_format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
     xioctl(droidcam_device_fd, VIDIOC_S_FMT, &vid_format);
+#endif
 
     int ret = xioctl(droidcam_device_fd, VIDIOC_G_FMT, &vid_format);
     if (ret < 0) {


### PR DESCRIPTION
I've modified lines 99 and 100 from `decoder_v4l2.c`, I surrounded them with an ifdef linux preprocessor directive.

From:

```c
    vid_format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
    xioctl(droidcam_device_fd, VIDIOC_S_FMT, &vid_format);
```

To:

```c
#ifdef __linux__
    vid_format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
    xioctl(droidcam_device_fd, VIDIOC_S_FMT, &vid_format);
#endif
```

due to the way webcamd is implemented the current code fails with EINVAL (errno 22), fixing that error results in EBUSY; the only solution found thus far is this one.

After testing the app for a while no other bugs where found.